### PR TITLE
added missing img alt attribute in LoginwithGoogle.js

### DIFF
--- a/chainkeeper_app/src/components/BlockPage.js
+++ b/chainkeeper_app/src/components/BlockPage.js
@@ -21,7 +21,7 @@ class BlockPage extends Component {
 
   componentDidMount() {
        this.setState({ isLoading: true });
-       let openVal = parseInt(this.props.match.params.id);
+       let openVal = parseInt(this.props.match.params.id,10);
 
         fetch("http://192.248.22.171:8080/blocksci/api/v5/block/"+openVal)
               .then(response => response.json())

--- a/chainkeeper_app/src/components/LoginwithGoogle.js
+++ b/chainkeeper_app/src/components/LoginwithGoogle.js
@@ -45,7 +45,7 @@ class LoginwithGoogle extends Component {
         };
         return (
            <div>
-              <img className="google_login" src={require('../public/images/gmail_login.png')} style={{width:"200px"}} onClick={() => imageClick()} />
+              <img className="google_login" alt = "google login"src={require('../public/images/gmail_login.png')} style={{width:"200px"}} onClick={() => imageClick()} />
            </div>
         );
      }


### PR DESCRIPTION
fixes #31 
`<img className="google_login" alt = "google login"src={require('../public/images/gmail_login.png')} style={{width:"200px"}} onClick={() => imageClick()} />`