### PR TITLE
FIx Issue 44 and MInor change to the Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ ChainKeeper is a web application to explore and analyze block-chain data for use
 ### Installation
 
 ```sh
-$ cd ChainKeeper
-$ npm install 
+$ cd ChainKeeper/chainkeeper_app
+$ npm install
 $ npm start
 ```
 

--- a/chainkeeper_api/README.md
+++ b/chainkeeper_api/README.md
@@ -2,6 +2,10 @@
 
 API calls are available with CORS headers. More APIs will be added in soon. 
 
+##### Install Requirements
+
+  - pip install -r requirements.txt
+
 ##### Single Block Data
 
   - End Point - <b>http://domain.com/blocksci/api/v5/block/$block_height</b>

--- a/chainkeeper_api/requirements.txt
+++ b/chainkeeper_api/requirements.txt
@@ -1,0 +1,2 @@
+Flask==1.1.1
+flask_cors==3.0.8

--- a/chainkeeper_app/package.json
+++ b/chainkeeper_app/package.json
@@ -20,5 +20,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "optionalDependencies": {
+    "fsevents": "^2.1.2"
   }
 }


### PR DESCRIPTION
The installation steps mentioned in the Readme file were -
cd ChainKeeper
npm install
npm start

The problem was that the main ChainKeeper directory doesn't contain the package.json file. It is inside the ChainKeeper/chainkeeper_app/. So I updated the Readme to reflect the same.

Added fsevents as an optional dependency in the package.json file to keep the npm install from giving errors.